### PR TITLE
Moved README back to README.md.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,5 @@
-# StarPy Asterisk Protocols for Twisted
+StarPy Asterisk Protocols for Twisted
+=====================================
 
 StarPy is a Python + Twisted protocol that provides access to the Asterisk
 PBX's Manager Interface (AMI) and Fast Asterisk Gateway Interface (FastAGI).

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     author_email='mcfletch@vrplumber.com',
     description='Twisted Protocols for interaction with the Asterisk PBX',
     license='BSD',
-    long_description=open('README.txt').read(),
+    long_description=open('README.rst').read(),
     keywords='asterisk manager fastagi twisted AMI',
     url='http://asterisk-org.github.com/starpy',
     packages=find_packages(),


### PR DESCRIPTION
This makes the main GitHub page all pretty and HTMLish.

I'm not sure why this was changed, but are there any objections to changing it back?
