### PR TITLE
Add README.rst to MANIFEST.in so that the sdist can be built

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include *.txt
 include LICENSE
+include README.rst
 recursive-include examples *.txt *.py


### PR DESCRIPTION
README.rst needs to be added to the manifest so that the source distribution can be built with setup.py.
