### PR TITLE
manager login: support for challenge response

### DIFF
--- a/starpy/manager.py
+++ b/starpy/manager.py
@@ -576,7 +576,7 @@ class AMIProtocol(basic.LineOnlyReceiver):
             }).addCallback(self.errorUnlessResponse)
         self.id = self.factory.id
         return self.sendDeferred({
-            'action':   'Challenge',
+            'action': 'Challenge',
             'authtype': 'MD5',
         }).addCallback(sendResponse)
 


### PR DESCRIPTION
AMIFactory changes:
- New attribute named plaintext_login.
- Defaults to True, keeping backwards compatibility.

AMIProtocol changes:
- New method loginChallengeResponse().
- Called instead of login() by connectionMade() if the factory's
  plaintext_login attribute is False.

Note: these changes follow existing code architecture and conventions, even though AMIFactory's login() docstring states the existing approach is messy. But that's to be eventually addressed under a different scope. :)

Thanks in advance for your review.
