### PR TITLE
Include completion event with response elements

### DIFF
--- a/starpy/manager.py
+++ b/starpy/manager.py
@@ -346,6 +346,7 @@ class AMIProtocol(basic.LineOnlyReceiver):
             if event.get('response') == 'Error':
                 df.errback(error.AMICommandFailure(event))
             elif event.get('event') == stopEvent:
+                cache.append(event)
                 df.callback(cache)
             else:
                 cache.append(event)


### PR DESCRIPTION
This change causes the event that signals completion of a collectDeferred call to be appended to the array of events returned to the success callback. Currently, only the list ack and list elements are provided, but the completion event itself can provide important information.
