### PR TITLE
AMI Originate - Update/fix multiple variable support

### DIFF
--- a/starpy/manager.py
+++ b/starpy/manager.py
@@ -710,25 +710,24 @@ class AMIProtocol(basic.LineOnlyReceiver):
         variable -- variables associated to the call
         async -- make the origination asynchronous
         """
-        variable = ','.join(["%s=%s" % (x[0], x[1]) for x in variable.items()])
-        message = dict([(k, v) for (k, v) in {
-            'action': 'originate',
-            'channel': channel,
-            'context': context,
-            'exten': exten,
-            'priority': priority,
-            'timeout': timeout,
-            'callerid': callerid,
-            'account': account,
-            'application': application,
-            'data': data,
-            'variable': variable,
-            'async': str(async),
-            'channelid': channelid,
-            'otherchannelid': otherchannelid
-        }.items() if v is not None])
-        if 'timeout' in message:
-            message['timeout'] = message['timeout'] * 1000
+        message = [(k, v) for (k, v) in (
+            ('action', 'originate'),
+            ('channel', channel),
+            ('context', context),
+            ('exten', exten),
+            ('priority', priority),
+            ('callerid', callerid),
+            ('account', account),
+            ('application', application),
+            ('data', data),
+            ('async', str(async)),
+            ('channelid', channelid),
+            ('otherchannelid', otherchannelid),
+        ) if v is not None]
+        if timeout is not None:
+            message.append(('timeout', timeout*1000))
+        for var_name, var_value in variable.items():
+            message.append(('variable', '%s=%s' % (var_name, var_value)))
         return self.sendDeferred(message).addCallback(self.errorUnlessResponse)
 
     def park(self, channel, channel2, timeout):


### PR DESCRIPTION
Changing AMI Originate to send multiple variables as multiple entries of the "Variable" key, as per documentation of Asterisk 1.4 onwards.

Now sends:

    > Action: Originate
    > Variable: VAR_A=va
    > Variable: VAR_B=vb
    > ...

Instead of the single key with comma-separated variables:

    > Action: Originate
    > Variable: VAR_A=va,VAR_B=vb
    > ...

Motives:
- Asterisk 1.4, 1.8 and 11 were not responding correctly/consistently:
  - AMI Action "GetVar" was returning no values for any of the variables.
  - CLI "core show channel <chan>" showing an odd-looking "VAR_A=va,VAR_B=vb" in a single line in the "Variables:" section.
  - chan_sip seemed to be grabbing the "SIPADDHEADERS" variable we were using, to some degree of success.
- Following spec/docs, of course.

PS: Made possible based on the work from PR #24 which allows sending AMI Actions with repeated "keys".

Final notes:
- Not sure where the comma-separated implementation came from and eventual backward compatibility requirements. Should that be addressed? Maybe Asterisk 1.2 and earlier have an AMI/1.0 implementation distinct from 1.4's? Any pointers?
- Again, per docs, the current implementation seems to be missing valid keys ("earlymedia" and "codecs", for example); for the purpose of this PR and, of course, to restrcit the commit changes, all of these were left unchanged. It may make sense to review/revamp originate's implementation (again, this may be related to older AMI implementations).
- Last but not least, as a side comment, the new sendMessage implementation, from PR #24, includes lots of code duplication and could be improved. Would you be willing to accept such a proposal?

Thanks for your review and feedback.