### PR TITLE
New AMI Command Output Format Support

### DIFF
--- a/starpy/manager.py
+++ b/starpy/manager.py
@@ -214,6 +214,7 @@ class AMIProtocol(basic.LineOnlyReceiver):
         self.actionIDCallbacks.clear()
         self.eventTypeCallbacks.clear()
     VERSION_PREFIX = 'Asterisk Call Manager'
+    END_DATA = '--END COMMAND--'
 
     def dispatchIncoming(self):
         """Dispatch any finished incoming events/messages"""
@@ -223,23 +224,27 @@ class AMIProtocol(basic.LineOnlyReceiver):
             line = self.messageCache.pop(0)
             line = line.strip()
             if line:
-                if line.startswith(self.VERSION_PREFIX):
-                    self.amiVersion = line[
-                                len(self.VERSION_PREFIX) + 1:].strip()
+                if line.endswith(self.END_DATA):
+                    # multi-line command results...
+                    message.setdefault(' ', []).extend([
+                        l for l in line.split('\n')
+                                if (l and l != self.END_DATA)
+                    ])
                 else:
-                    try:
-                        key, value = line.split(':', 1)
-                    except ValueError, err:
-                        # XXX data-safety issues, what prevents the
-                        # VERSION_PREFIX from showing up in a data-set?
-                        log.warn("Improperly formatted line received and "
-                                 "ignored: %r", line)
+                    # regular line...
+                    if line.startswith(self.VERSION_PREFIX):
+                        self.amiVersion = line[
+                                    len(self.VERSION_PREFIX) + 1:].strip()
                     else:
-                        key = key.lower().strip()
-                        if key in message:
-                            message[key] += "\r\n" + value.strip()
+                        try:
+                            key, value = line.split(':', 1)
+                        except ValueError, err:
+                            # XXX data-safety issues, what prevents the
+                            # VERSION_PREFIX from showing up in a data-set?
+                            log.warn("Improperly formatted line received and "
+                                     "ignored: %r", line)
                         else:
-                            message[key] = value.strip()
+                            message[key.lower().strip()] = value.strip()
         log.debug('Incoming Message: %s', message)
         if 'actionid' in message:
             key = message['actionid']
@@ -429,10 +434,10 @@ class AMIProtocol(basic.LineOnlyReceiver):
             'command': command
         }
         df = self.sendDeferred(message)
-        df.addCallback(self.errorUnlessResponse)
+        df.addCallback(self.errorUnlessResponse, expected='Follows')
 
         def onResult(message):
-            return message['output']
+            return message[' ']
 
         return df.addCallback(onResult)
 

--- a/starpy/manager.py
+++ b/starpy/manager.py
@@ -27,6 +27,7 @@ from twisted.protocols import basic
 from twisted.internet import error as tw_error
 import socket
 import logging
+from distutils.version import LooseVersion
 from hashlib import md5
 from starpy import error
 
@@ -226,10 +227,8 @@ class AMIProtocol(basic.LineOnlyReceiver):
             if line:
                 if line.endswith(self.END_DATA):
                     # multi-line command results...
-                    message.setdefault(' ', []).extend([
-                        l for l in line.split('\n')
-                                if (l and l != self.END_DATA)
-                    ])
+                    line = line[0:-len(self.END_DATA)]
+                    message['output'] = '\r\n'.join(line.split('\n'))
                 else:
                     # regular line...
                     if line.startswith(self.VERSION_PREFIX):
@@ -244,7 +243,11 @@ class AMIProtocol(basic.LineOnlyReceiver):
                             log.warn("Improperly formatted line received and "
                                      "ignored: %r", line)
                         else:
-                            message[key.lower().strip()] = value.strip()
+                            key = key.lower().strip()
+                            if key in message:
+                                message[key] += '\r\n' + value.strip()
+                            else:
+                                message[key] = value.strip();
         log.debug('Incoming Message: %s', message)
         if 'actionid' in message:
             key = message['actionid']
@@ -434,10 +437,13 @@ class AMIProtocol(basic.LineOnlyReceiver):
             'command': command
         }
         df = self.sendDeferred(message)
-        df.addCallback(self.errorUnlessResponse, expected='Follows')
+        if LooseVersion(self.amiVersion) > LooseVersion('2.7.0'):
+            df.addCallback(self.errorUnlessResponse)
+        else:
+            df.addCallback(self.errorUnlessResponse, expected='Follows')
 
         def onResult(message):
-            return message[' ']
+            return message['output'].split ('\r\n')
 
         return df.addCallback(onResult)
 


### PR DESCRIPTION
The change modifies how the response from AMI command actions are
processed to support a new proposed format:
https://reviewboard.asterisk.org/r/4391/

As part of the change, non-unique headers are now concatenated
together separated by "\r\n". Note: chan_sip already sends non-unique
headers when outputting the ChanVariables for a peer.
