### PR TITLE
starpy/manager: AMI autoconnect after failed connection

### DIFF
--- a/examples/priexhaustionbare.py
+++ b/examples/priexhaustionbare.py
@@ -34,7 +34,7 @@ class ChannelTracker( propertied.Propertied ):
 		self.addCallbacks( deferred )
 	def onAMIFailed(self, reason):
 		"""Failed connection handler"""
-		log.error("""Connection failed: """)
+		log.info("""Connection failed. Trying to reconnect...""")
 		log.debug("""Reason: %s""" % reason)
 	def addCallbacks( self, deferred=None ):
 		"""Callbacks setting helper"""

--- a/examples/priexhaustionbare.py
+++ b/examples/priexhaustionbare.py
@@ -35,7 +35,7 @@ class ChannelTracker( propertied.Propertied ):
 	def onAMIFailed(self, reason):
 		"""Failed connection handler"""
 		log.info("""Connection failed. Trying to reconnect...""")
-		log.debug("""Reason: %s""" % reason)
+		log.debug("""Reason: %s""", reason)
 	def addCallbacks( self, deferred=None ):
 		"""Callbacks setting helper"""
 		deferred.addCallback( self.onAMIConnect )

--- a/examples/priexhaustionbare.py
+++ b/examples/priexhaustionbare.py
@@ -1,64 +1,94 @@
 #! /usr/bin/env python
+
+import os, logging, pprint, time
+import random
 from twisted.application import service, internet
 from twisted.internet import reactor, defer
 from starpy import manager, fastagi
 import utilapplication
 import menu
-import os, logging, pprint, time
 from basicproperty import common, propertied, basic
 
-log = logging.getLogger( 'priexhaustion' )
-log.setLevel( logging.INFO )
 
-class ChannelTracker( propertied.Propertied ):
-	"""Track open channels on the Asterisk server"""
-	channels = common.DictionaryProperty(
-		"channels", """Set of open channels on the system""",
-	)
-	thresholdCount = common.IntegerProperty(
-		"thresholdCount", """Storage of threshold below which we don't warn user""",
-		defaultValue = 20,
-	)
-	def main( self ):
-		"""Main operation for the channel-tracking demo"""
-		amiDF = APPLICATION.amiSpecifier.login( 
-		).addCallback( self.onAMIConnect )
-	def onAMIConnect( self, ami ):
-		ami.status().addCallback( self.onStatus, ami=ami )
-		ami.registerEvent( 'Hangup', self.onChannelHangup )
-		ami.registerEvent( 'Newchannel', self.onChannelNew )
-	def onStatus( self, events, ami=None ):
-		"""Integrate the current status into our set of channels"""
-		log.debug( """Initial channel status retrieved""" )
-		for event in events:
-			self.onChannelNew( ami, event )
-	def onChannelNew( self, ami, event ):
-		"""Handle creation of a new channel"""
-		log.debug( """Start on channel %s""", event )
-		opening = not self.channels.has_key( event['uniqueid'] )
-		self.channels[ event['uniqueid'] ] = event 
-		if opening:
-			self.onChannelChange( ami, event, opening = opening )
-	def onChannelHangup( self, ami, event ):
-		"""Handle hangup of an existing channel"""
-		try:
-			del self.channels[ event['uniqueid']]
-		except KeyError, err:
-			log.warn( """Hangup on unknown channel %s""", event )
-		else:
-			log.debug( """Hangup on channel %s""", event )
-		self.onChannelChange( ami, event, opening = False )
-	def onChannelChange( self, ami, event, opening=False ):
-		"""Channel count has changed, do something useful like enforcing limits"""
-		if opening and len(self.channels) > self.thresholdCount:
-			log.warn( """Current channel count: %s""", len(self.channels ) )
-		else:
-			log.info( """Current channel count: %s""", len(self.channels ) )
+log = logging.getLogger('priexhaustion')
+log.setLevel(logging.DEBUG)
+
+
+class ChannelTracker(propertied.Propertied):
+    """Track open channels on the Asterisk server"""
+    channels = common.DictionaryProperty(
+        "channels",
+        """Set of open channels on the system""",
+    )
+    thresholdCount = common.IntegerProperty(
+        "thresholdCount",
+        """Storage of threshold below which we don't warn user""",
+        defaultValue=20,
+    )
+
+    def main(self):
+        """Main operation for the channel-tracking demo"""
+        deferred = APPLICATION.amiSpecifier.login(on_reconnect=self.onAMIReconnect)
+        self.addCallbacks(deferred)
+
+    def onAMIReconnect(self, deferred=None):
+        """Callback for AMIFactory's reconnect event"""
+        log.debug("""Reconnecting""")
+        self.addCallbacks(deferred)
+
+    def addCallacks(self, deferred=None)
+        """Callbacks setting helper"""
+        deferred.addCallback(self.onAMIConnect)
+        deferred.addErrback(self.onAMIFailed)
+
+    def onAMIConnect(self, ami):
+        """Connection handler"""
+        self.delay = self.initialDelay
+        ami.status().addCallback(self.onStatus, ami=ami)
+        ami.registerEvent('Hangup', self.onChannelHangup)
+        ami.registerEvent('Newchannel', self.onChannelNew)
+
+    def onAMIFailed(self, reason):
+        """Failed connection handler"""
+        log.error("""Connection failed: """)
+        log.debug("""Reason: %s""" % reason)
+
+    def onStatus(self, events, ami=None):
+        """Integrate the current status into our set of channels"""
+        log.debug("""Initial channel status retrieved""")
+        for event in events:
+            self.onChannelNew(ami, event)
+
+    def onChannelNew(self, ami, event):
+        """Handle creation of a new channel"""
+        log.debug("""Start on channel %s""", event)
+        if 'uniqueid' in event:
+            opening = not event['uniqueid'] in self.channels
+            self.channels[event['uniqueid']] = event
+            if opening:
+                self.onChannelChange(ami, event, opening=opening)
+
+    def onChannelHangup(self, ami, event):
+        """Handle hangup of an existing channel"""
+        try:
+            del self.channels[event['uniqueid']]
+        except KeyError, err:
+            log.warn("""Hangup on unknown channel %s""", event)
+        else:
+            log.debug("""Hangup on channel %s""", event)
+        self.onChannelChange(ami, event, opening=False)
+
+    def onChannelChange(self, ami, event, opening=False):
+        """Channel count has changed, do something useful like enforcing limits"""
+        if opening and len(self.channels) > self.thresholdCount:
+            log.warn("""Current channel count: %s""", len(self.channels))
+        else:
+            log.info("""Current channel count: %s""", len(self.channels))
 
 APPLICATION = utilapplication.UtilApplication()
 
 if __name__ == "__main__":
-	logging.basicConfig()
-	tracker = ChannelTracker()
-	reactor.callWhenRunning( tracker.main )
-	reactor.run()
+    logging.basicConfig()
+    tracker = ChannelTracker()
+    reactor.callWhenRunning(tracker.main)
+    reactor.run()

--- a/examples/priexhaustionbare.py
+++ b/examples/priexhaustionbare.py
@@ -1,94 +1,78 @@
 #! /usr/bin/env python
-
-import os, logging, pprint, time
-import random
 from twisted.application import service, internet
 from twisted.internet import reactor, defer
 from starpy import manager, fastagi
 import utilapplication
 import menu
+import os, logging, pprint, time
 from basicproperty import common, propertied, basic
 
+log = logging.getLogger( 'priexhaustion' )
+log.setLevel( logging.INFO )
 
-log = logging.getLogger('priexhaustion')
-log.setLevel(logging.DEBUG)
-
-
-class ChannelTracker(propertied.Propertied):
-    """Track open channels on the Asterisk server"""
-    channels = common.DictionaryProperty(
-        "channels",
-        """Set of open channels on the system""",
-    )
-    thresholdCount = common.IntegerProperty(
-        "thresholdCount",
-        """Storage of threshold below which we don't warn user""",
-        defaultValue=20,
-    )
-
-    def main(self):
-        """Main operation for the channel-tracking demo"""
-        deferred = APPLICATION.amiSpecifier.login(on_reconnect=self.onAMIReconnect)
-        self.addCallbacks(deferred)
-
-    def onAMIReconnect(self, deferred=None):
-        """Callback for AMIFactory's reconnect event"""
-        log.debug("""Reconnecting""")
-        self.addCallbacks(deferred)
-
-    def addCallbacks(self, deferred=None)
-        """Callbacks setting helper"""
-        deferred.addCallback(self.onAMIConnect)
-        deferred.addErrback(self.onAMIFailed)
-
-    def onAMIConnect(self, ami):
-        """Connection handler"""
-        self.delay = self.initialDelay
-        ami.status().addCallback(self.onStatus, ami=ami)
-        ami.registerEvent('Hangup', self.onChannelHangup)
-        ami.registerEvent('Newchannel', self.onChannelNew)
-
-    def onAMIFailed(self, reason):
-        """Failed connection handler"""
-        log.error("""Connection failed: """)
-        log.debug("""Reason: %s""" % reason)
-
-    def onStatus(self, events, ami=None):
-        """Integrate the current status into our set of channels"""
-        log.debug("""Initial channel status retrieved""")
-        for event in events:
-            self.onChannelNew(ami, event)
-
-    def onChannelNew(self, ami, event):
-        """Handle creation of a new channel"""
-        log.debug("""Start on channel %s""", event)
-        if 'uniqueid' in event:
-            opening = not event['uniqueid'] in self.channels
-            self.channels[event['uniqueid']] = event
-            if opening:
-                self.onChannelChange(ami, event, opening=opening)
-
-    def onChannelHangup(self, ami, event):
-        """Handle hangup of an existing channel"""
-        try:
-            del self.channels[event['uniqueid']]
-        except KeyError, err:
-            log.warn("""Hangup on unknown channel %s""", event)
-        else:
-            log.debug("""Hangup on channel %s""", event)
-        self.onChannelChange(ami, event, opening=False)
-
-    def onChannelChange(self, ami, event, opening=False):
-        """Channel count has changed, do something useful like enforcing limits"""
-        if opening and len(self.channels) > self.thresholdCount:
-            log.warn("""Current channel count: %s""", len(self.channels))
-        else:
-            log.info("""Current channel count: %s""", len(self.channels))
+class ChannelTracker( propertied.Propertied ):
+	"""Track open channels on the Asterisk server"""
+	channels = common.DictionaryProperty(
+		"channels", """Set of open channels on the system""",
+	)
+	thresholdCount = common.IntegerProperty(
+		"thresholdCount", """Storage of threshold below which we don't warn user""",
+		defaultValue = 20,
+	)
+	def main( self ):
+		"""Main operation for the channel-tracking demo"""
+		deferred = APPLICATION.amiSpecifier.login( on_reconnect=self.onAMIReconnect )
+		self.addCallbacks( deferred )
+	def onAMIConnect( self, ami ):
+		"""Connection handler"""
+		ami.status().addCallback( self.onStatus, ami=ami )
+		ami.registerEvent( 'Hangup', self.onChannelHangup )
+		ami.registerEvent( 'Newchannel', self.onChannelNew )
+	def onAMIReconnect( self, deferred=None ):
+		"""Callback for AMIFactory's reconnect event"""
+		log.debug("""Reconnecting""")
+		self.addCallbacks( deferred )
+	def onAMIFailed(self, reason):
+		"""Failed connection handler"""
+		log.error("""Connection failed: """)
+		log.debug("""Reason: %s""" % reason)
+	def addCallbacks( self, deferred=None ):
+		"""Callbacks setting helper"""
+		deferred.addCallback( self.onAMIConnect )
+		deferred.addErrback( self.onAMIFailed )
+	def onStatus( self, events, ami=None ):
+		"""Integrate the current status into our set of channels"""
+		log.debug( """Initial channel status retrieved""" )
+		for event in events:
+			self.onChannelNew( ami, event )
+	def onChannelNew( self, ami, event ):
+		"""Handle creation of a new channel"""
+		log.debug( """Start on channel %s""", event )
+		if 'uniqueid' in event:
+			opening = not event['uniqueid'] in self.channels
+			self.channels[ event['uniqueid'] ] = event
+			if opening:
+				self.onChannelChange( ami, event, opening = opening )
+	def onChannelHangup( self, ami, event ):
+		"""Handle hangup of an existing channel"""
+		try:
+			del self.channels[ event['uniqueid']]
+		except KeyError, err:
+			log.warn( """Hangup on unknown channel %s""", event )
+		else:
+			log.debug( """Hangup on channel %s""", event )
+		self.onChannelChange( ami, event, opening = False )
+	def onChannelChange( self, ami, event, opening=False ):
+		"""Channel count has changed, do something useful like enforcing limits"""
+		if opening and len(self.channels) > self.thresholdCount:
+			log.warn( """Current channel count: %s""", len(self.channels ) )
+		else:
+			log.info( """Current channel count: %s""", len(self.channels ) )
 
 APPLICATION = utilapplication.UtilApplication()
 
 if __name__ == "__main__":
-    logging.basicConfig()
-    tracker = ChannelTracker()
-    reactor.callWhenRunning(tracker.main)
-    reactor.run()
+	logging.basicConfig()
+	tracker = ChannelTracker()
+	reactor.callWhenRunning( tracker.main )
+	reactor.run()

--- a/examples/priexhaustionbare.py
+++ b/examples/priexhaustionbare.py
@@ -36,7 +36,7 @@ class ChannelTracker(propertied.Propertied):
         log.debug("""Reconnecting""")
         self.addCallbacks(deferred)
 
-    def addCallacks(self, deferred=None)
+    def addCallbacks(self, deferred=None)
         """Callbacks setting helper"""
         deferred.addCallback(self.onAMIConnect)
         deferred.addErrback(self.onAMIFailed)

--- a/examples/utilapplication.py
+++ b/examples/utilapplication.py
@@ -1,6 +1,6 @@
 #
 # StarPy -- Asterisk Protocols for Twisted
-# 
+#
 # Copyright (c) 2006, Michael C. Fletcher
 #
 # Michael C. Fletcher <mcfletch@vrplumber.com>
@@ -15,15 +15,16 @@
 # details.
 
 """Class providing utility applications with common support code"""
+import logging,os
 from basicproperty import common, propertied, basic, weak
 from ConfigParser import ConfigParser
 from starpy import fastagi, manager
 from twisted.internet import defer, reactor
-import logging,os
 
-log = logging.getLogger( 'app' )
+log = logging.getLogger('app')
 
-class UtilApplication( propertied.Propertied ):
+
+class UtilApplication(propertied.Propertied):
     """Utility class providing simple application-level operations
 
     FastAGI entry points are waitForCallOn and handleCallsFor, which allow
@@ -32,82 +33,99 @@ class UtilApplication( propertied.Propertied ):
     (as specified in self.configFiles).
     """
     amiSpecifier = basic.BasicProperty(
-        "amiSpecifier", """AMI connection specifier for the application see AMISpecifier""",
-        defaultFunction = lambda prop,client: AMISpecifier()
-    )
+        "amiSpecifier",
+        """AMI connection specifier for the application see AMISpecifier""",
+        defaultFunction=lambda prop, client: AMISpecifier()
+        )
     agiSpecifier = basic.BasicProperty(
-        "agiSpecifier", """FastAGI server specifier for the application see AGISpecifier""",
-        defaultFunction = lambda prop,client: AGISpecifier()
-    )
+        "agiSpecifier",
+        """FastAGI server specifier for the application see AGISpecifier""",
+        defaultFunction=lambda prop, client: AGISpecifier()
+        )
     extensionWaiters = common.DictionaryProperty(
-        "extensionWaiters", """Set of deferreds waiting for incoming extensions""",
-    )
+        "extensionWaiters",
+        """Set of deferreds waiting for incoming extensions""",
+        )
     extensionHandlers = common.DictionaryProperty(
-        "extensionHandlers", """Set of permanant callbacks waiting for incoming extensions""",
-    )
-    configFiles = configFiles=('starpy.conf','~/.starpy.conf')
-    def __init__( self ):
+        "extensionHandlers",
+        """Set of permanant callbacks waiting for incoming extensions""",
+        )
+    configFiles = configFiles = ('starpy.conf', '~/.starpy.conf')
+
+    def __init__(self):
         """Initialise the application from options in configFile"""
         self.loadConfigurations()
-    def loadConfigurations( self ):
-        parser = self._loadConfigFiles( self.configFiles )
-        self._copyPropertiesFrom( parser, 'AMI', self.amiSpecifier )
-        self._copyPropertiesFrom( parser, 'FastAGI', self.agiSpecifier )
+
+    def loadConfigurations(self):
+        parser = self._loadConfigFiles(self.configFiles)
+        self._copyPropertiesFrom(parser, 'AMI', self.amiSpecifier)
+        self._copyPropertiesFrom(parser, 'FastAGI', self.agiSpecifier)
         return parser
-    def _loadConfigFiles( self, configFiles ):
+
+    def _loadConfigFiles(self, configFiles):
         """Load options from configuration files given (if present)"""
-        parser = ConfigParser( )
+        parser = ConfigParser()
         filenames = [
-            os.path.abspath( os.path.expandvars( os.path.expanduser( file ) ))
+            os.path.abspath(os.path.expandvars(os.path.expanduser(file)))
             for file in configFiles
         ]
-        log.info( "Possible configuration files:\n\t%s", "\n\t".join(filenames) or None)
+        log.info("Possible configuration files:\n\t%s",
+                 "\n\t".join(filenames) or None)
         filenames = [
             file for file in filenames
             if os.path.isfile(file)
         ]
-        log.info( "Actual configuration files:\n\t%s", "\n\t".join(filenames) or None)
-        parser.read( filenames )
+        log.info("Actual configuration files:\n\t%s",
+                 "\n\t".join(filenames) or None)
+        parser.read(filenames)
         return parser
-    def _copyPropertiesFrom( self, parser, section, client, properties=None ):
+
+    def _copyPropertiesFrom(self, parser, section, client, properties=None):
         """Copy properties from the config-parser's given section into client"""
         if properties is None:
             properties = client.getProperties()
         for property in properties:
-            if parser.has_option( section, property.name ):
+            if parser.has_option(section, property.name):
                 try:
-                    value = parser.get( section, property.name )
-                    setattr( client, property.name, value )
-                except (TypeError,ValueError,AttributeError,NameError), err:
-                    log( """Unable to set property %r of %r to config-file value %r: %s"""%(
-                        property.name, client, parser.get( section, property.name, 1), err,
-                    ))
+                    value = parser.get(section, property.name)
+                    setattr(client, property.name, value)
+                except (TypeError, ValueError, AttributeError, NameError), err:
+                    log("""Unable to set property %r of %r to config-file value %r: %s""" % (
+                        property.name,
+                        client,
+                        parser.get(section, property.name, 1),
+                        err,
+                      ))
         return client
-    def dispatchIncomingCall( self, agi ):
+
+    def dispatchIncomingCall(self, agi):
         """Handle an incoming call (dispatch to the appropriate registered handler)"""
         extension = agi.variables['agi_extension']
-        log.info( """AGI connection with extension: %r""",  extension )
+        log.info("""AGI connection with extension: %r""",  extension)
         try:
-            df = self.extensionWaiters.pop( extension )
+            df = self.extensionWaiters.pop(extension)
         except KeyError, err:
             try:
-                callback = self.extensionHandlers[ extension ]
+                callback = self.extensionHandlers[extension]
             except KeyError, err:
                 try:
-                    callback = self.extensionHandlers[ None ]
+                    callback = self.extensionHandlers[None]
                 except KeyError, err:
-                    log.warn( """Unexpected connection to extension %r: %s""", extension, agi.variables )
+                    log.warn("""Unexpected connection to extension %r: %s""",
+                             extension, agi.variables)
                     agi.finish()
                     return
             try:
-                return callback( agi )
+                return callback(agi)
             except Exception, err:
-                log.error( """Failure during callback %s for agi %s: %s""", callback, agi.variables, err )
+                log.error("""Failure during callback %s for agi %s: %s""",
+                          callback, agi.variables, err)
                 # XXX return a -1 here
         else:
             if not df.called:
-                df.callback( agi )
-    def waitForCallOn( self, extension, timeout=15 ):
+                df.callback(agi)
+
+    def waitForCallOn(self, extension, timeout=15):
         """Wait for an AGI call on extension given
 
         extension -- string extension for which to wait
@@ -122,17 +140,20 @@ class UtilApplication( propertied.Propertied ):
         returns deferred returning connected FastAGIProtocol or an error
         """
         extension = str(extension)
-        log.info( 'Waiting for extension %r for %s seconds', extension, timeout )
-        df = defer.Deferred( )
-        self.extensionWaiters[ extension ] = df
-        def onTimeout( ):
+        log.info('Waiting for extension %r for %s seconds', extension, timeout)
+        df = defer.Deferred()
+        self.extensionWaiters[extension] = df
+
+        def onTimeout():
             if not df.called:
-                df.errback( defer.TimeoutError(
-                    """Timeout waiting for call on extension: %r"""%(extension,)
-                ))
-        reactor.callLater( timeout, onTimeout )
+                df.errback(defer.TimeoutError(
+                    """Timeout waiting for call on extension: %r"""
+                    % (extension,)
+                    ))
+        reactor.callLater(timeout, onTimeout)
         return df
-    def handleCallsFor( self, extension, callback ):
+
+    def handleCallsFor(self, extension, callback):
         """Register permanant handler for given extension
 
         extension -- string extension for which to wait or None to define
@@ -150,49 +171,56 @@ class UtilApplication( propertied.Propertied ):
         """
         if extension is not None:
             extension = str(extension)
-        self.extensionHandlers[ extension ] = callback
+        self.extensionHandlers[extension] = callback
 
-class AMISpecifier( propertied.Propertied ):
+
+class AMISpecifier(propertied.Propertied):
     """Manager interface setup/specifier"""
     username = common.StringLocaleProperty(
         "username", """Login username for the manager interface""",
-    )
+        )
     secret = common.StringLocaleProperty(
         "secret", """Login secret for the manager interface""",
-    )
+        )
     password = secret
     server = common.StringLocaleProperty(
         "server", """Server IP address to which to connect""",
-        defaultValue = '127.0.0.1',
-    )
+        defaultValue='127.0.0.1',
+        )
     port = common.IntegerProperty(
         "port", """Server IP port to which to connect""",
-        defaultValue = 5038,
-    )
+        defaultValue=5038,
+        )
     timeout = common.FloatProperty(
         "timeout", """Timeout in seconds for an AMI connection timeout""",
-        defaultValue = 5.0,
-    )
-    def login( self ):
+        defaultValue=5.0,
+        )
+
+    def login(self, on_reconnect=None):
         """Login to the specified manager via the AMI"""
-        theManager = manager.AMIFactory(self.username, self.secret)
+        theManager = manager.AMIFactory(self.username,
+                                        self.secret,
+                                        on_reconnect=on_reconnect)
         return theManager.login(self.server, self.port, timeout=self.timeout)
 
-class AGISpecifier( propertied.Propertied ):
+
+class AGISpecifier(propertied.Propertied):
     """Specifier of where we send the user to connect to our AGI"""
     port = common.IntegerProperty(
         "port", """IP port on which to listen""",
-        defaultValue = 4573,
-    )
+        defaultValue=4573,
+        )
     interface = common.StringLocaleProperty(
-        "interface", """IP interface on which to listen (local only by default)""",
-        defaultValue = '127.0.0.1',
-    )
+        "interface",
+        """IP interface on which to listen (local only by default)""",
+        defaultValue='127.0.0.1',
+        )
     context = common.StringLocaleProperty(
         "context", """Asterisk context to which to connect incoming calls""",
-        defaultValue = 'survey',
-    )
-    def run( self, mainFunction ):
+        defaultValue='survey',
+        )
+
+    def run(self, mainFunction):
         """Start up the AGI server with the given mainFunction"""
         f = fastagi.FastAGIFactory(mainFunction)
         return reactor.listenTCP(self.port, f, 50, self.interface)

--- a/examples/utilapplication.py
+++ b/examples/utilapplication.py
@@ -1,6 +1,6 @@
 #
 # StarPy -- Asterisk Protocols for Twisted
-#
+# 
 # Copyright (c) 2006, Michael C. Fletcher
 #
 # Michael C. Fletcher <mcfletch@vrplumber.com>
@@ -15,16 +15,15 @@
 # details.
 
 """Class providing utility applications with common support code"""
-import logging,os
 from basicproperty import common, propertied, basic, weak
 from ConfigParser import ConfigParser
 from starpy import fastagi, manager
 from twisted.internet import defer, reactor
+import logging,os
 
-log = logging.getLogger('app')
+log = logging.getLogger( 'app' )
 
-
-class UtilApplication(propertied.Propertied):
+class UtilApplication( propertied.Propertied ):
     """Utility class providing simple application-level operations
 
     FastAGI entry points are waitForCallOn and handleCallsFor, which allow
@@ -33,99 +32,82 @@ class UtilApplication(propertied.Propertied):
     (as specified in self.configFiles).
     """
     amiSpecifier = basic.BasicProperty(
-        "amiSpecifier",
-        """AMI connection specifier for the application see AMISpecifier""",
-        defaultFunction=lambda prop, client: AMISpecifier()
-        )
+        "amiSpecifier", """AMI connection specifier for the application see AMISpecifier""",
+        defaultFunction = lambda prop,client: AMISpecifier()
+    )
     agiSpecifier = basic.BasicProperty(
-        "agiSpecifier",
-        """FastAGI server specifier for the application see AGISpecifier""",
-        defaultFunction=lambda prop, client: AGISpecifier()
-        )
+        "agiSpecifier", """FastAGI server specifier for the application see AGISpecifier""",
+        defaultFunction = lambda prop,client: AGISpecifier()
+    )
     extensionWaiters = common.DictionaryProperty(
-        "extensionWaiters",
-        """Set of deferreds waiting for incoming extensions""",
-        )
+        "extensionWaiters", """Set of deferreds waiting for incoming extensions""",
+    )
     extensionHandlers = common.DictionaryProperty(
-        "extensionHandlers",
-        """Set of permanant callbacks waiting for incoming extensions""",
-        )
-    configFiles = configFiles = ('starpy.conf', '~/.starpy.conf')
-
-    def __init__(self):
+        "extensionHandlers", """Set of permanant callbacks waiting for incoming extensions""",
+    )
+    configFiles = configFiles=('starpy.conf','~/.starpy.conf')
+    def __init__( self ):
         """Initialise the application from options in configFile"""
         self.loadConfigurations()
-
-    def loadConfigurations(self):
-        parser = self._loadConfigFiles(self.configFiles)
-        self._copyPropertiesFrom(parser, 'AMI', self.amiSpecifier)
-        self._copyPropertiesFrom(parser, 'FastAGI', self.agiSpecifier)
+    def loadConfigurations( self ):
+        parser = self._loadConfigFiles( self.configFiles )
+        self._copyPropertiesFrom( parser, 'AMI', self.amiSpecifier )
+        self._copyPropertiesFrom( parser, 'FastAGI', self.agiSpecifier )
         return parser
-
-    def _loadConfigFiles(self, configFiles):
+    def _loadConfigFiles( self, configFiles ):
         """Load options from configuration files given (if present)"""
-        parser = ConfigParser()
+        parser = ConfigParser( )
         filenames = [
-            os.path.abspath(os.path.expandvars(os.path.expanduser(file)))
+            os.path.abspath( os.path.expandvars( os.path.expanduser( file ) ))
             for file in configFiles
         ]
-        log.info("Possible configuration files:\n\t%s",
-                 "\n\t".join(filenames) or None)
+        log.info( "Possible configuration files:\n\t%s", "\n\t".join(filenames) or None)
         filenames = [
             file for file in filenames
             if os.path.isfile(file)
         ]
-        log.info("Actual configuration files:\n\t%s",
-                 "\n\t".join(filenames) or None)
-        parser.read(filenames)
+        log.info( "Actual configuration files:\n\t%s", "\n\t".join(filenames) or None)
+        parser.read( filenames )
         return parser
-
-    def _copyPropertiesFrom(self, parser, section, client, properties=None):
+    def _copyPropertiesFrom( self, parser, section, client, properties=None ):
         """Copy properties from the config-parser's given section into client"""
         if properties is None:
             properties = client.getProperties()
         for property in properties:
-            if parser.has_option(section, property.name):
+            if parser.has_option( section, property.name ):
                 try:
-                    value = parser.get(section, property.name)
-                    setattr(client, property.name, value)
-                except (TypeError, ValueError, AttributeError, NameError), err:
-                    log("""Unable to set property %r of %r to config-file value %r: %s""" % (
-                        property.name,
-                        client,
-                        parser.get(section, property.name, 1),
-                        err,
-                      ))
+                    value = parser.get( section, property.name )
+                    setattr( client, property.name, value )
+                except (TypeError,ValueError,AttributeError,NameError), err:
+                    log( """Unable to set property %r of %r to config-file value %r: %s"""%(
+                        property.name, client, parser.get( section, property.name, 1), err,
+                    ))
         return client
-
-    def dispatchIncomingCall(self, agi):
+    def dispatchIncomingCall( self, agi ):
         """Handle an incoming call (dispatch to the appropriate registered handler)"""
         extension = agi.variables['agi_extension']
-        log.info("""AGI connection with extension: %r""",  extension)
+        log.info( """AGI connection with extension: %r""",  extension )
         try:
-            df = self.extensionWaiters.pop(extension)
+            df = self.extensionWaiters.pop( extension )
         except KeyError, err:
             try:
-                callback = self.extensionHandlers[extension]
+                callback = self.extensionHandlers[ extension ]
             except KeyError, err:
                 try:
-                    callback = self.extensionHandlers[None]
+                    callback = self.extensionHandlers[ None ]
                 except KeyError, err:
-                    log.warn("""Unexpected connection to extension %r: %s""",
-                             extension, agi.variables)
+                    log.warn( """Unexpected connection to extension %r: %s""", extension, agi.variables )
                     agi.finish()
                     return
             try:
-                return callback(agi)
+                return callback( agi )
             except Exception, err:
-                log.error("""Failure during callback %s for agi %s: %s""",
-                          callback, agi.variables, err)
+                log.error( """Failure during callback %s for agi %s: %s""", callback, agi.variables, err )
                 # XXX return a -1 here
         else:
             if not df.called:
-                df.callback(agi)
-
-    def waitForCallOn(self, extension, timeout=15):
+                df.callback( agi )
+    def waitForCallOn( self, extension, timeout=15 ):
         """Wait for an AGI call on extension given
 
         extension -- string extension for which to wait
@@ -140,20 +122,17 @@ class UtilApplication(propertied.Propertied):
         returns deferred returning connected FastAGIProtocol or an error
         """
         extension = str(extension)
-        log.info('Waiting for extension %r for %s seconds', extension, timeout)
-        df = defer.Deferred()
-        self.extensionWaiters[extension] = df
-
-        def onTimeout():
+        log.info( 'Waiting for extension %r for %s seconds', extension, timeout )
+        df = defer.Deferred( )
+        self.extensionWaiters[ extension ] = df
+        def onTimeout( ):
             if not df.called:
-                df.errback(defer.TimeoutError(
-                    """Timeout waiting for call on extension: %r"""
-                    % (extension,)
-                    ))
-        reactor.callLater(timeout, onTimeout)
+                df.errback( defer.TimeoutError(
+                    """Timeout waiting for call on extension: %r"""%(extension,)
+                ))
+        reactor.callLater( timeout, onTimeout )
         return df
-
-    def handleCallsFor(self, extension, callback):
+    def handleCallsFor( self, extension, callback ):
         """Register permanant handler for given extension
 
         extension -- string extension for which to wait or None to define
@@ -171,56 +150,49 @@ class UtilApplication(propertied.Propertied):
         """
         if extension is not None:
             extension = str(extension)
-        self.extensionHandlers[extension] = callback
+        self.extensionHandlers[ extension ] = callback
 
-
-class AMISpecifier(propertied.Propertied):
+class AMISpecifier( propertied.Propertied ):
     """Manager interface setup/specifier"""
     username = common.StringLocaleProperty(
         "username", """Login username for the manager interface""",
-        )
+    )
     secret = common.StringLocaleProperty(
         "secret", """Login secret for the manager interface""",
-        )
+    )
     password = secret
     server = common.StringLocaleProperty(
         "server", """Server IP address to which to connect""",
-        defaultValue='127.0.0.1',
-        )
+        defaultValue = '127.0.0.1',
+    )
     port = common.IntegerProperty(
         "port", """Server IP port to which to connect""",
-        defaultValue=5038,
-        )
+        defaultValue = 5038,
+    )
     timeout = common.FloatProperty(
         "timeout", """Timeout in seconds for an AMI connection timeout""",
-        defaultValue=5.0,
-        )
-
-    def login(self, on_reconnect=None):
+        defaultValue = 5.0,
+    )
+    def login( self, on_reconnect=None ):
         """Login to the specified manager via the AMI"""
-        theManager = manager.AMIFactory(self.username,
-                                        self.secret,
-                                        on_reconnect=on_reconnect)
+        theManager = manager.AMIFactory(self.username, self.secret, on_reconnect=on_reconnect)
         return theManager.login(self.server, self.port, timeout=self.timeout)
 
-
-class AGISpecifier(propertied.Propertied):
+class AGISpecifier( propertied.Propertied ):
     """Specifier of where we send the user to connect to our AGI"""
     port = common.IntegerProperty(
         "port", """IP port on which to listen""",
-        defaultValue=4573,
-        )
+        defaultValue = 4573,
+    )
     interface = common.StringLocaleProperty(
-        "interface",
-        """IP interface on which to listen (local only by default)""",
-        defaultValue='127.0.0.1',
-        )
+        "interface", """IP interface on which to listen (local only by default)""",
+        defaultValue = '127.0.0.1',
+    )
     context = common.StringLocaleProperty(
         "context", """Asterisk context to which to connect incoming calls""",
-        defaultValue='survey',
-        )
-
-    def run(self, mainFunction):
+        defaultValue = 'survey',
+    )
+    def run( self, mainFunction ):
         """Start up the AGI server with the given mainFunction"""
         f = fastagi.FastAGIFactory(mainFunction)
         return reactor.listenTCP(self.port, f, 50, self.interface)

--- a/starpy/manager.py
+++ b/starpy/manager.py
@@ -1111,12 +1111,16 @@ class AMIFactory(protocol.ReconnectingClientFactory):
     def clientConnectionFailed(self, connector, reason):
         """Connection failed, report to our callers"""
         self.loginDefer.errback(reason)
+        self.reconnect(connector)
 
     def clientConnectionLost(self, connector, unused_reason):
         """Connection lost, re-build the login connection"""
         log.info('connection lost, reconnecting...')
+        log.debug(self.on_reconnect)
+        self.reconnect(connector)
+
+    def reconnect(self, connector):
         self.retry(connector)
         self.loginDefer = defer.Deferred()
-        log.info(self.on_reconnect)
         if self.on_reconnect:
             self.on_reconnect(self.loginDefer)


### PR DESCRIPTION
In this commit I propose to add ability to reconnect after connection fail in **manager.AMIFactory** (as in parent class **protocol.ReconnectingClientFactory**). By the moment AMIFactory can reconnect only after short connection loss, but it would be more convenient (IMHO), if AMIFactory survived longer timeouts. So, the call to 'retry' method was added to AMIFactory.clientConnectionFailed implementation.

To test such activity a class ChannelTracker from examples/priexhaustionbare.py was used. Three new methods were added there and some bugs were fixed. 'login' method of the class AMISpecifier in examples/utilapplication.py was changed accordingly.

So, after applying changes in this commit, it will be possible to auto-connect to Asterisk server even after connection was lost for relatively long time (from several seconds and up).
